### PR TITLE
ap_private: Initialize data member in default constructor to avoid compilation warnings

### DIFF
--- a/include/etc/ap_private.h
+++ b/include/etc/ap_private.h
@@ -1590,7 +1590,8 @@ ASSIGN_OP_FROM_INT(double)
   }
 
  public:
-  INLINE ap_private() {
+  INLINE ap_private() 
+      : VAL(0) {
     set_canary();
     clearUnusedBits();
     check_canary();
@@ -3302,6 +3303,7 @@ class ap_private<_AP_W, _AP_S, false> {
   ///  for object deserialization (pair this with the static method Read).
   INLINE ap_private() {
     set_canary();
+    memset(pVal, 0, _AP_N * sizeof(uint64_t));
     clearUnusedBits();
     check_canary();
   }


### PR DESCRIPTION
This change fixes the compilation warnings like [a]. Both `VAL` and `pVal` are properly initialized in all `ap_private` constructor except the default one. This PR explicitly initialize these data members on default constructor too.

[a]

```
In member function 'clearUnusedBits',
    inlined from '__ct ' at hls//include/etc/ap_private.h:1595:20,
    inlined from '__ct_base ' at hls//include/ap_common.h:248:18,
    inlined from '__ct ' at hls//include/ap_int_base.h:208:3,
    inlined from 'operator&' at hls//include/ap_int_base.h:1436:1,
    inlined from 'clusterEnergy' at cmssw/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:872:54,
    inlined from 'compareClusterET' at cmssw/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:962:52:
  hls//include/etc/ap_private.h:2109:27: warning: 'MEM[(volatile struct ap_private *)&D.9255].VAL' is used uninitialized [-Wuninitialized]
  2109 |             ? ((((int64_t)VAL) << (excess_bits)) >> (excess_bits))
```
```
In member function 'clearUnusedBits',
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hls/2019.08-b8a1533230929513077d97b1507ff465/include/etc/ap_private.h:3305:20,
    inlined from '__ct_base ' at hls/include/ap_common.h:248:18,
    inlined from '__ct ' at hls/include/ap_int_base.h:179:61,
    inlined from 'operator-' at hls/include/ap_int_base.h:1321:1:
  hls/include/etc/ap_private.h:3397:33: warning: 'MEM[(volatile struct ap_private *)&lhs].pVal[1]' is used uninitialized [-Wuninitialized]
  3397 |         _AP_S ? ((((int64_t)pVal[_AP_N - 1]) << (excess_bits)) >> excess_bits)
```